### PR TITLE
Add GitHub Actions workflow to publish NuGet package on merge to main

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,47 @@
+name: Publish NuGet Package
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to publish (e.g. 1.0.9). Overrides the version in .csproj.'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Build, Test & Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+
+      - name: Override version (manual trigger only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          sed -i 's|<Version>.*</Version>|<Version>${{ inputs.version }}</Version>|' CustomAutoAdapterMapper/CustomAutoAdapterMapper.csproj
+          echo "Version set to ${{ inputs.version }}"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: dotnet pack CustomAutoAdapterMapper/CustomAutoAdapterMapper.csproj --configuration Release --no-build --output ./nupkg
+
+      - name: Publish to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Supports automatic publish on push to main and manual dispatch with an optional version override input. Requires NUGET_API_KEY repository secret.