### PR TITLE
Fix Create Mode doubling, add IsItemEmpty callback (v1.1.0)

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -31,6 +31,12 @@ jobs:
           sed -i 's|<Version>.*</Version>|<Version>${{ inputs.version }}</Version>|' CustomAutoAdapterMapper/CustomAutoAdapterMapper.csproj
           echo "Version set to ${{ inputs.version }}"
 
+      - name: Generate package icon (SVG -> PNG)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y librsvg2-bin
+          rsvg-convert -w 256 -h 256 branding/icon.svg -o branding/icon.png
+
       - name: Restore dependencies
         run: dotnet restore CustomAutoAdapterMapper/CustomAutoAdapterMapper.sln
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ obj
 CustomAutoAdapterMapper/.vs/
 bin/
 .idea
+TestResults/
+.claude/
+branding/icon.png

--- a/CustomAutoAdapterMapper.Tests/ExceptionTests.cs
+++ b/CustomAutoAdapterMapper.Tests/ExceptionTests.cs
@@ -1,0 +1,74 @@
+using CustomAutoAdapterMapper.Exceptions;
+
+namespace CustomAutoAdapterMapper.Tests;
+
+public class ExceptionTests
+{
+    [Test]
+    public void ItemKeyOptionNullExceptionDefaultConstructor()
+    {
+        var ex = new ItemKeyOptionNullException();
+        Assert.That(ex, Is.InstanceOf<Exception>());
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void ItemKeyOptionNullExceptionWithMessageAndInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new ItemKeyOptionNullException("outer", inner);
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+
+    [Test]
+    public void JsonContentExceptionDefaultConstructor()
+    {
+        var ex = new JsonContentException();
+        Assert.That(ex, Is.InstanceOf<Exception>());
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void JsonContentExceptionWithMessageAndInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new JsonContentException("outer", inner);
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+
+    [Test]
+    public void RootKeyOptionNullExceptionDefaultConstructor()
+    {
+        var ex = new RootKeyOptionNullException();
+        Assert.That(ex, Is.InstanceOf<Exception>());
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void RootKeyOptionNullExceptionWithMessageAndInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new RootKeyOptionNullException("outer", inner);
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+
+    [Test]
+    public void RootKeyPropertyNullExceptionDefaultConstructor()
+    {
+        var ex = new RootKeyPropertyNullException();
+        Assert.That(ex, Is.InstanceOf<Exception>());
+        Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void RootKeyPropertyNullExceptionWithMessageAndInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new RootKeyPropertyNullException("outer", inner);
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        Assert.That(ex.InnerException, Is.SameAs(inner));
+    }
+}

--- a/CustomAutoAdapterMapper.Tests/MapperTests.cs
+++ b/CustomAutoAdapterMapper.Tests/MapperTests.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace CustomAutoAdapterMapper.Tests;
 
-public class Tests
+public class MapperTests
 {
     private string _result;
 
@@ -366,5 +366,244 @@ public class Tests
 
         Assert.That(result.Count, Is.EqualTo(1));
         Assert.That(result.First().Description, Is.EqualTo("First"));
+    }
+
+    [Test]
+    public void TestCreateModeClearsDestinationWhenAllItemKeyValuesAreEmpty()
+    {
+        var json = @"{'products': [
+            {'product_name': 'ServiceA', 'description': 'First'},
+            {'product_name': 'ServiceB', 'description': 'Second'}
+        ]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = null, Description = "ghost-1" },
+            new TestObject { Title = "",   Description = "ghost-2" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Title", "product_name" },
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(2));
+        Assert.That(result.Any(r => r.Description == "ghost-1"), Is.False);
+        Assert.That(result.Any(r => r.Description == "ghost-2"), Is.False);
+        Assert.That(result.Select(r => r.Title), Is.EquivalentTo(new[] { "ServiceA", "ServiceB" }));
+    }
+
+    [Test]
+    public void TestUpdateModeStillRunsWhenSomeItemKeysArePopulated()
+    {
+        var json = @"{'products': [
+            {'product_name': 'ServiceA', 'description': 'Fresh'}
+        ]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "ServiceA", Description = "old" },
+            new TestObject { Title = null,       Description = "ghost" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Title", "product_name" },
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(2));
+        Assert.That(result.First(r => r.Title == "ServiceA").Description, Is.EqualTo("Fresh"));
+        Assert.That(result.Any(r => r.Description == "ghost"), Is.True);
+    }
+
+    [Test]
+    public void TestIsItemEmptyCallbackTriggersCreateModeAndClearsDestination()
+    {
+        var json = @"{'products': [
+            {'product_name': 'ServiceA', 'description': 'First'},
+            {'product_name': 'ServiceB', 'description': 'Second'}
+        ]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "ServiceA", Description = null, Brand = null },
+            new TestObject { Title = "ServiceB", Description = null, Brand = null }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.IsItemEmpty = item => string.IsNullOrEmpty(((TestObject)item).Description);
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Title", "product_name" },
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(2));
+        Assert.That(result.All(r => !string.IsNullOrEmpty(r.Description)), Is.True);
+    }
+
+    [Test]
+    public void TestIsItemEmptyCallbackTakesPrecedenceOverItemKeyDefault()
+    {
+        var json = @"{'products': [
+            {'product_name': 'ServiceA', 'description': 'Fresh'}
+        ]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "ServiceA", Description = "old" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.IsItemEmpty = _ => true;
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Title", "product_name" },
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result.First().Description, Is.EqualTo("Fresh"));
+        Assert.That(result.Any(r => r.Description == "old"), Is.False);
+    }
+
+    [Test]
+    public void TestUpdateModeReturnsEarlyWhenItemKeyDoesNotExistOnDestinationType()
+    {
+        var json = @"{'products': [{'product_name': 'A', 'description': 'Fresh'}]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "A", Description = "old" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "NonExistentProperty";
+            options.IsItemEmpty = _ => false;
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result.First().Description, Is.EqualTo("old"));
+    }
+
+    [Test]
+    public void TestUpdateModeReturnsEarlyWhenItemKeyValueIsNullOnDestinationItem()
+    {
+        var json = @"{'products': [{'title': 'A', 'description': 'Fresh'}]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = null, Description = "old" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.IsItemEmpty = _ => false;
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result.First().Description, Is.EqualTo("old"));
+    }
+
+    [Test]
+    public void TestUpdateModeSkipsEmptyMappedJsonValuesForExistingItem()
+    {
+        var json = @"{'products': [{'title': 'A', 'description': ''}]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "A", Description = "original" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "Title";
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.First().Description, Is.EqualTo("original"));
+    }
+
+    [Test]
+    public void TestDefaultEmptyCheckTreatsNonExistentItemKeyPropertyAsEmpty()
+    {
+        var json = @"{'products': [{'product_name': 'A', 'description': 'Fresh'}]}";
+
+        var destinationCollection = new List<TestObject>
+        {
+            new TestObject { Title = "A", Description = "ghost" }
+        };
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.ItemKey = "NonExistentProperty";
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "Title", "product_name" },
+                { "Description", "description" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result.First().Title, Is.EqualTo("A"));
+        Assert.That(result.First().Description, Is.EqualTo("Fresh"));
+        Assert.That(result.Any(r => r.Description == "ghost"), Is.False);
+    }
+
+    [Test]
+    public void TestSetPropertyValueSkipsReadOnlyProperties()
+    {
+        var json = @"{'products': [{'ro': 'newval'}]}";
+
+        var destinationCollection = new List<TestObjectWithReadOnly>();
+
+        var result = json.MapCollection(destinationCollection, options =>
+        {
+            options.RootKey = "products";
+            options.Mappings = new Dictionary<string, string>
+            {
+                { "ReadOnlyField", "ro" }
+            };
+        });
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result.First().ReadOnlyField, Is.EqualTo("fixed"));
     }
 }

--- a/CustomAutoAdapterMapper.Tests/TestObjectWithReadOnly.cs
+++ b/CustomAutoAdapterMapper.Tests/TestObjectWithReadOnly.cs
@@ -1,0 +1,7 @@
+namespace CustomAutoAdapterMapper.Tests;
+
+public class TestObjectWithReadOnly
+{
+    public string Title { get; set; }
+    public string ReadOnlyField { get; } = "fixed";
+}

--- a/CustomAutoAdapterMapper/CustomAutoAdapterMapper.csproj
+++ b/CustomAutoAdapterMapper/CustomAutoAdapterMapper.csproj
@@ -9,8 +9,9 @@
         <RepositoryUrl>https://github.com/teghoz/CustomAutoAdapterMapper</RepositoryUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>license.txt</PackageLicenseFile>
-        <Version>1.0.8</Version>
-        <PackageReleaseNotes>v1.0.8: Fixed ItemKey mapping logic to correctly identify update vs create mode, preventing duplicate records in collections.</PackageReleaseNotes>
+        <PackageIcon>icon.png</PackageIcon>
+        <Version>1.1.0</Version>
+        <PackageReleaseNotes>v1.1.0: Create Mode now clears the destination list before populating, fixing a doubling bug when callers reused a partially-populated list with empty ItemKey values. Adds optional IsItemEmpty callback on Option for caller-defined emptiness rules.</PackageReleaseNotes>
         <PackageProjectUrl>https://github.com/teghoz/CustomAutoAdapterMapper</PackageProjectUrl>
     </PropertyGroup>
 
@@ -20,6 +21,10 @@
             <PackagePath>\</PackagePath>
         </None>
         <None Include="..\README.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\branding\icon.png" Condition="Exists('..\branding\icon.png')">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>

--- a/CustomAutoAdapterMapper/Mapper.cs
+++ b/CustomAutoAdapterMapper/Mapper.cs
@@ -20,6 +20,9 @@ namespace CustomAutoAdapterMapper
             var entries = rootProperty.ToList();
 
             if (MapperShouldIterateThroughEntireIncomingCollection(destination, mapperOptions))
+            {
+                destination?.Clear();
+
                 foreach (var entry in entries)
                 {
                     var collectionItem = Activator.CreateInstance<T>();
@@ -28,6 +31,7 @@ namespace CustomAutoAdapterMapper
                     SeedMappedPropertiesOfItem(entry, collectionItem, mapperOptions);
                     destination.Add(collectionItem);
                 }
+            }
             else
                 foreach (var entry in destination)
                     SeedKnownCollectionOfItem(entries, entry, mapperOptions);
@@ -50,15 +54,18 @@ namespace CustomAutoAdapterMapper
 
         private static bool MapperShouldIterateThroughEntireIncomingCollection<T>(List<T> destination, Option options)
         {
-            // First check if the ItemKey property exists and has values in destination
-            var itemKeyIdentifierIsEmpty = destination != null &&
-                                           !string.IsNullOrEmpty(options.ItemKey) &&
-                                           destination.All(x =>
-                                               string.IsNullOrEmpty(x.GetType()?.GetProperty(options.ItemKey)
-                                                   ?.GetValue(x)?.ToString() ?? string.Empty));
+            if (destination == null || destination.Count == 0) return true;
 
-            var result = destination == null || destination.Count == 0 || itemKeyIdentifierIsEmpty;
-            return result;
+            // Caller-provided emptiness rule takes precedence over the ItemKey-based default.
+            if (options.IsItemEmpty != null)
+                return destination.All(x => options.IsItemEmpty(x));
+
+            // Default: treat the collection as empty when every item has an empty ItemKey value.
+            if (string.IsNullOrEmpty(options.ItemKey)) return false;
+
+            return destination.All(x =>
+                string.IsNullOrEmpty(x.GetType()?.GetProperty(options.ItemKey)
+                    ?.GetValue(x)?.ToString() ?? string.Empty));
         }
 
         private static void SeedCollectionItem<T>(JToken entry, T collectionItem)

--- a/CustomAutoAdapterMapper/Option.cs
+++ b/CustomAutoAdapterMapper/Option.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace CustomAutoAdapterMapper
@@ -8,6 +9,7 @@ namespace CustomAutoAdapterMapper
         public string RootKey { get; set; }
         public string ItemKey { get; set; }
         public Dictionary<string, string> Mappings { get; set; }
+        public Func<object, bool> IsItemEmpty { get; set; }
 
         public List<string> MappingKeys
         {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="branding/icon.svg" alt="CustomAutoAdapterMapper" width="128" height="128">
+</p>
+
 # CustomAutoAdapterMapper
 
 [![NuGet](https://img.shields.io/nuget/v/CustomAutoAdapterMapper.svg)](https://www.nuget.org/packages/CustomAutoAdapterMapper/)

--- a/branding/icon.svg
+++ b/branding/icon.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="44" fill="url(#bg)"/>
+
+  <!-- { -->
+  <path d="M 70 64 Q 50 64 50 84 L 50 116 Q 50 128 38 128 Q 50 128 50 140 L 50 172 Q 50 192 70 192"
+        stroke="white" stroke-width="9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- } -->
+  <path d="M 106 64 Q 126 64 126 84 L 126 116 Q 126 128 138 128 Q 126 128 126 140 L 126 172 Q 126 192 106 192"
+        stroke="white" stroke-width="9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- arrow -->
+  <path d="M 150 128 L 184 128 M 174 116 L 188 128 L 174 140"
+        stroke="white" stroke-width="7" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- object box on right -->
+  <rect x="196" y="74" width="42" height="108" rx="7" fill="white"/>
+  <line x1="204" y1="96"  x2="230" y2="96"  stroke="#1d4ed8" stroke-width="4" stroke-linecap="round"/>
+  <line x1="204" y1="116" x2="230" y2="116" stroke="#1d4ed8" stroke-width="4" stroke-linecap="round"/>
+  <line x1="204" y1="136" x2="222" y2="136" stroke="#1d4ed8" stroke-width="4" stroke-linecap="round"/>
+  <line x1="204" y1="156" x2="226" y2="156" stroke="#1d4ed8" stroke-width="4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
The mode selector treated a list of empty-ItemKey items as "effectively empty" and entered Create Mode, but the Create branch appended rather than replaced — silently doubling destinations. Create now clears the list before populating.

IsItemEmpty lets callers express domain-specific emptiness rules where the default ItemKey check doesn't fit.

Adds full test coverage for the new behavior, the four typed exceptions, and previously-uncovered Update Mode edge cases. Adds package branding (SVG icon converted to PNG by the publish workflow).